### PR TITLE
Generate bootstrap step artifacts

### DIFF
--- a/bootstrap/step0.json
+++ b/bootstrap/step0.json
@@ -1,0 +1,8 @@
+{
+  "step": 0,
+  "digit": 0,
+  "bucket": [
+    720
+  ],
+  "explanation": "Numbers with ones digit 0: 720"
+}

--- a/bootstrap/step1.json
+++ b/bootstrap/step1.json
@@ -1,0 +1,6 @@
+{
+  "step": 1,
+  "digit": 1,
+  "bucket": [],
+  "explanation": "No numbers with ones digit 1."
+}

--- a/bootstrap/step2.json
+++ b/bootstrap/step2.json
@@ -1,0 +1,6 @@
+{
+  "step": 2,
+  "digit": 2,
+  "bucket": [],
+  "explanation": "No numbers with ones digit 2."
+}

--- a/bootstrap/step3.json
+++ b/bootstrap/step3.json
@@ -1,0 +1,6 @@
+{
+  "step": 3,
+  "digit": 3,
+  "bucket": [],
+  "explanation": "No numbers with ones digit 3."
+}

--- a/bootstrap/step4.json
+++ b/bootstrap/step4.json
@@ -1,0 +1,6 @@
+{
+  "step": 4,
+  "digit": 4,
+  "bucket": [],
+  "explanation": "No numbers with ones digit 4."
+}

--- a/bootstrap/step5.json
+++ b/bootstrap/step5.json
@@ -1,0 +1,8 @@
+{
+  "step": 5,
+  "digit": 5,
+  "bucket": [
+    355
+  ],
+  "explanation": "Numbers with ones digit 5: 355"
+}

--- a/bootstrap/step6.json
+++ b/bootstrap/step6.json
@@ -1,0 +1,8 @@
+{
+  "step": 6,
+  "digit": 6,
+  "bucket": [
+    436
+  ],
+  "explanation": "Numbers with ones digit 6: 436"
+}

--- a/bootstrap/step7.json
+++ b/bootstrap/step7.json
@@ -1,0 +1,9 @@
+{
+  "step": 7,
+  "digit": 7,
+  "bucket": [
+    457,
+    657
+  ],
+  "explanation": "Numbers with ones digit 7: 457, 657"
+}

--- a/bootstrap/step8.json
+++ b/bootstrap/step8.json
@@ -1,0 +1,6 @@
+{
+  "step": 8,
+  "digit": 8,
+  "bucket": [],
+  "explanation": "No numbers with ones digit 8."
+}

--- a/bootstrap/step9.json
+++ b/bootstrap/step9.json
@@ -1,0 +1,9 @@
+{
+  "step": 9,
+  "digit": 9,
+  "bucket": [
+    329,
+    839
+  ],
+  "explanation": "Numbers with ones digit 9: 329, 839"
+}

--- a/tools/generate_bootstrap_steps.js
+++ b/tools/generate_bootstrap_steps.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const numbers = [329, 457, 657, 839, 436, 720, 355];
+const outputDir = path.join(__dirname, '..', 'bootstrap');
+
+fs.mkdirSync(outputDir, { recursive: true });
+
+for (let digit = 0; digit <= 9; digit += 1) {
+  const bucket = numbers.filter((value) => Math.floor(value / 1) % 10 === digit);
+  const data = {
+    step: digit,
+    digit,
+    bucket,
+    explanation: bucket.length
+      ? `Numbers with ones digit ${digit}: ${bucket.join(', ')}`
+      : `No numbers with ones digit ${digit}.`,
+  };
+
+  const filePath = path.join(outputDir, `step${digit}.json`);
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+console.log(`Generated files for steps 0-9 in ${outputDir}`);


### PR DESCRIPTION
## Summary
- [x] add a generator script for bootstrap step data
- [x] commit generated JSON files for steps 0-9

## Testing
- [ ] Not run (not applicable)

## Diffs
```diff
+ const numbers = [329, 457, 657, 839, 436, 720, 355];
+ const outputDir = path.join(__dirname, '..', 'bootstrap');
+ fs.mkdirSync(outputDir, { recursive: true });
+ for (let digit = 0; digit <= 9; digit += 1) {
+   const bucket = numbers.filter((value) => Math.floor(value / 1) % 10 === digit);
+   const data = {
+     step: digit,
+     digit,
+     bucket,
+     explanation: bucket.length
+       ? `Numbers with ones digit ${digit}: ${bucket.join(', ')}`
+       : `No numbers with ones digit ${digit}.`,
+   };
+   const filePath = path.join(outputDir, `step${digit}.json`);
+   fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+ }
```

------
https://chatgpt.com/codex/tasks/task_e_68e4c163fe28832988308be3e2559c4c