### PR TITLE
Add SQL Server migrations and seed tooling for API package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Algorithm Repository
+
+本專案包含多個範例與服務。以下說明如何在 `packages/api` 下執行資料庫 Migration 與 Seed。
+
+## 如何執行 migration/seed
+
+1. 進入 API 專案資料夾並安裝依賴：
+   ```bash
+   cd packages/api
+   npm install
+   ```
+2. 設定連線所需的環境變數（例如 `DB_HOST`、`DB_USER`、`DB_PASSWORD`、`DB_NAME` 等）。
+3. 執行 Migration：
+   ```bash
+   npm run db:migrate
+   ```
+4. 執行 Seed 匯入 Demo 資料：
+   ```bash
+   npm run db:seed
+   ```
+
+Migration/Seed 皆會使用 `src/db/pool.ts` 中設定的 MSSQL 連線池設定，請依照實際環境調整。

--- a/packages/api/migrations/001_init.sql
+++ b/packages/api/migrations/001_init.sql
@@ -1,0 +1,108 @@
+-- Tenants/Users/RBAC
+CREATE TABLE Tenants(
+    id INT IDENTITY PRIMARY KEY,
+    name NVARCHAR(100) NOT NULL,
+    plan NVARCHAR(20) NOT NULL DEFAULT 'free',
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+
+CREATE TABLE Users(
+    id INT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    email NVARCHAR(150) UNIQUE NOT NULL,
+    password_hash VARBINARY(256) NOT NULL,
+    name NVARCHAR(80),
+    role NVARCHAR(20) NOT NULL,
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_Users_Tenant ON Users(tenant_id);
+
+-- Channels（接 Telegram/LINE/FB）
+CREATE TABLE Channels(
+    id INT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    type NVARCHAR(20) NOT NULL,
+    config_json NVARCHAR(MAX) NOT NULL,
+    status NVARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_Channels_Tenant ON Channels(tenant_id);
+
+-- Customers / Conversations / Messages
+CREATE TABLE Customers(
+    id BIGINT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    external_id NVARCHAR(200) NOT NULL,
+    display_name NVARCHAR(120),
+    last_channel_id INT NULL REFERENCES Channels(id),
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE UNIQUE INDEX UX_Customer_Tenant_Ext ON Customers(tenant_id, external_id);
+
+CREATE TABLE Conversations(
+    id BIGINT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    customer_id BIGINT NOT NULL REFERENCES Customers(id),
+    channel_id INT NOT NULL REFERENCES Channels(id),
+    status NVARCHAR(20) NOT NULL DEFAULT 'open',
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME(),
+    updated_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_Conversations_Tenant_Status ON Conversations(tenant_id, status);
+
+CREATE TABLE Messages(
+    id BIGINT IDENTITY PRIMARY KEY,
+    conversation_id BIGINT NOT NULL REFERENCES Conversations(id),
+    direction NVARCHAR(10) NOT NULL,
+    msg_type NVARCHAR(20) NOT NULL,
+    content NVARCHAR(MAX) NOT NULL,
+    meta_json NVARCHAR(MAX),
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_Messages_Conv ON Messages(conversation_id);
+
+-- FAQs
+CREATE TABLE FAQs(
+    id INT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    question NVARCHAR(500) NOT NULL,
+    answer NVARCHAR(MAX) NOT NULL,
+    enabled BIT NOT NULL DEFAULT 1,
+    tags NVARCHAR(200),
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_FAQs_Tenant ON FAQs(tenant_id);
+
+-- Forms / Submissions（訂位/訂餐 表單）
+CREATE TABLE Forms(
+    id INT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    name NVARCHAR(100) NOT NULL,
+    schema_json NVARCHAR(MAX) NOT NULL,
+    trigger_keywords NVARCHAR(300),
+    enabled BIT NOT NULL DEFAULT 1,
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+
+CREATE TABLE FormSubmissions(
+    id BIGINT IDENTITY PRIMARY KEY,
+    tenant_id INT NOT NULL REFERENCES Tenants(id),
+    form_id INT NOT NULL REFERENCES Forms(id),
+    conversation_id BIGINT NOT NULL REFERENCES Conversations(id),
+    payload_json NVARCHAR(MAX) NOT NULL,
+    status NVARCHAR(20) NOT NULL DEFAULT 'new',
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_FormSub_Tenant ON FormSubmissions(tenant_id);
+
+-- Jobs（排程/通知）
+CREATE TABLE Jobs(
+    id BIGINT IDENTITY PRIMARY KEY,
+    tenant_id INT NULL,
+    type NVARCHAR(50) NOT NULL,
+    payload_json NVARCHAR(MAX) NOT NULL,
+    status NVARCHAR(20) NOT NULL DEFAULT 'pending',
+    run_at DATETIME2 NOT NULL,
+    created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+);
+CREATE INDEX IX_Jobs_StatusRunAt ON Jobs(status, run_at);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "db:migrate": "ts-node src/db/migrate.ts",
+    "db:seed": "ts-node src/db/seed.ts"
+  },
+  "dependencies": {
+    "mssql": "^9.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/api/src/db/migrate.ts
+++ b/packages/api/src/db/migrate.ts
@@ -1,0 +1,68 @@
+import { readdir, readFile } from 'fs/promises';
+import path from 'path';
+import { closePool, getPool, sql } from './pool';
+
+const MIGRATIONS_TABLE = 'SchemaMigrations';
+
+const migrationsDir = path.resolve(__dirname, '../../migrations');
+
+const ensureMigrationsTable = async (): Promise<void> => {
+  const pool = await getPool();
+  await pool
+    .request()
+    .batch(`
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[${MIGRATIONS_TABLE}]') AND type = 'U')
+BEGIN
+    CREATE TABLE [dbo].[${MIGRATIONS_TABLE}] (
+        id INT IDENTITY PRIMARY KEY,
+        filename NVARCHAR(255) NOT NULL UNIQUE,
+        applied_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+END`);
+};
+
+const runMigrations = async (): Promise<void> => {
+  const files = (await readdir(migrationsDir)).filter((file) => file.endsWith('.sql')).sort();
+  if (files.length === 0) {
+    console.log('No migrations found.');
+    return;
+  }
+
+  const pool = await getPool();
+
+  for (const file of files) {
+    const alreadyApplied = await pool
+      .request()
+      .input('filename', sql.NVarChar(255), file)
+      .query(`SELECT 1 FROM [dbo].[${MIGRATIONS_TABLE}] WHERE filename = @filename`);
+
+    if (alreadyApplied.recordset.length > 0) {
+      console.log(`Skipping already applied migration: ${file}`);
+      continue;
+    }
+
+    const fullPath = path.join(migrationsDir, file);
+    const sqlContent = await readFile(fullPath, 'utf-8');
+
+    console.log(`Applying migration: ${file}`);
+    await pool.request().batch(sqlContent);
+    await pool
+      .request()
+      .input('filename', sql.NVarChar(255), file)
+      .query(`INSERT INTO [dbo].[${MIGRATIONS_TABLE}] (filename) VALUES (@filename)`);
+  }
+};
+
+const main = async () => {
+  try {
+    await ensureMigrationsTable();
+    await runMigrations();
+  } catch (error) {
+    console.error('Migration failed', error);
+    process.exitCode = 1;
+  } finally {
+    await closePool();
+  }
+};
+
+void main();

--- a/packages/api/src/db/pool.ts
+++ b/packages/api/src/db/pool.ts
@@ -1,0 +1,50 @@
+import * as sql from 'mssql';
+
+type Maybe<T> = T | null;
+
+let pool: Maybe<sql.ConnectionPool> = null;
+
+const parseIntEnv = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const poolConfig: sql.config = {
+  server: process.env.DB_HOST ?? 'localhost',
+  port: parseIntEnv(process.env.DB_PORT, 1433),
+  user: process.env.DB_USER ?? 'sa',
+  password: process.env.DB_PASSWORD ?? '',
+  database: process.env.DB_NAME ?? 'chatbot',
+  options: {
+    encrypt: process.env.DB_ENCRYPT === 'true',
+    trustServerCertificate: process.env.DB_TRUST_CERT !== 'false',
+  },
+  pool: {
+    max: parseIntEnv(process.env.DB_POOL_MAX, 10),
+    min: parseIntEnv(process.env.DB_POOL_MIN, 0),
+    idleTimeoutMillis: parseIntEnv(process.env.DB_POOL_IDLE_TIMEOUT, 30000),
+  },
+};
+
+export const getPool = async (): Promise<sql.ConnectionPool> => {
+  if (pool && pool.connected) {
+    return pool;
+  }
+
+  if (pool && pool.connecting) {
+    return pool;
+  }
+
+  pool = await sql.connect(poolConfig);
+  return pool;
+};
+
+export const closePool = async (): Promise<void> => {
+  if (pool) {
+    await pool.close();
+    pool = null;
+  }
+};
+
+export { sql };

--- a/packages/api/src/db/seed.ts
+++ b/packages/api/src/db/seed.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'crypto';
+import { closePool, getPool, sql } from './pool';
+
+const DEMO_TENANT_NAME = 'Demo Cafe';
+const DEMO_OWNER_EMAIL = 'owner@demo.local';
+const DEMO_PASSWORD = '12345678';
+
+const ensureTenant = async (): Promise<number> => {
+  const pool = await getPool();
+  const existing = await pool
+    .request()
+    .input('name', sql.NVarChar(100), DEMO_TENANT_NAME)
+    .query('SELECT id FROM Tenants WHERE name = @name');
+
+  if (existing.recordset.length > 0) {
+    return existing.recordset[0].id as number;
+  }
+
+  const inserted = await pool
+    .request()
+    .input('name', sql.NVarChar(100), DEMO_TENANT_NAME)
+    .query(
+      "INSERT INTO Tenants (name, plan) OUTPUT INSERTED.id VALUES (@name, 'free')"
+    );
+
+  return inserted.recordset[0].id as number;
+};
+
+const ensureOwner = async (tenantId: number): Promise<number> => {
+  const pool = await getPool();
+  const existing = await pool
+    .request()
+    .input('email', sql.NVarChar(150), DEMO_OWNER_EMAIL)
+    .query('SELECT id FROM Users WHERE email = @email');
+
+  if (existing.recordset.length > 0) {
+    return existing.recordset[0].id as number;
+  }
+
+  const passwordHash = createHash('sha256').update(DEMO_PASSWORD).digest();
+
+  const inserted = await pool
+    .request()
+    .input('tenantId', sql.Int, tenantId)
+    .input('email', sql.NVarChar(150), DEMO_OWNER_EMAIL)
+    .input('passwordHash', sql.VarBinary(256), passwordHash)
+    .input('name', sql.NVarChar(80), 'Demo Owner')
+    .input('role', sql.NVarChar(20), 'owner')
+    .query(
+      'INSERT INTO Users (tenant_id, email, password_hash, name, role) OUTPUT INSERTED.id VALUES (@tenantId, @email, @passwordHash, @name, @role)'
+    );
+
+  return inserted.recordset[0].id as number;
+};
+
+const ensureTelegramChannel = async (tenantId: number): Promise<number> => {
+  const pool = await getPool();
+  const existing = await pool
+    .request()
+    .input('tenantId', sql.Int, tenantId)
+    .input('type', sql.NVarChar(20), 'telegram')
+    .query('SELECT id FROM Channels WHERE tenant_id = @tenantId AND type = @type');
+
+  if (existing.recordset.length > 0) {
+    return existing.recordset[0].id as number;
+  }
+
+  const config = {
+    botToken: '123456:ABCDEF-telegram-demo-token',
+    webhookUrl: 'https://demo.local/telegram/webhook',
+  };
+
+  const inserted = await pool
+    .request()
+    .input('tenantId', sql.Int, tenantId)
+    .input('type', sql.NVarChar(20), 'telegram')
+    .input('configJson', sql.NVarChar(sql.MAX), JSON.stringify(config))
+    .query(
+      "INSERT INTO Channels (tenant_id, type, config_json) OUTPUT INSERTED.id VALUES (@tenantId, @type, @configJson)"
+    );
+
+  return inserted.recordset[0].id as number;
+};
+
+const ensureFaqs = async (tenantId: number): Promise<void> => {
+  const pool = await getPool();
+  const faqs = [
+    {
+      question: '營業時間？',
+      answer: '我們每週二至週日 10:00-21:00 營業，週一公休。',
+      tags: 'general',
+    },
+    {
+      question: '是否提供外帶？',
+      answer: '提供外帶與外送服務，可透過 LINE 或電話訂購。',
+      tags: 'service',
+    },
+    {
+      question: '餐廳位置在哪裡？',
+      answer: '位於台北市中正區仁愛路 100 號，近捷運忠孝新生站。',
+      tags: 'location',
+    },
+  ];
+
+  for (const faq of faqs) {
+    const exists = await pool
+      .request()
+      .input('tenantId', sql.Int, tenantId)
+      .input('question', sql.NVarChar(500), faq.question)
+      .query('SELECT id FROM FAQs WHERE tenant_id = @tenantId AND question = @question');
+
+    if (exists.recordset.length > 0) {
+      continue;
+    }
+
+    await pool
+      .request()
+      .input('tenantId', sql.Int, tenantId)
+      .input('question', sql.NVarChar(500), faq.question)
+      .input('answer', sql.NVarChar(sql.MAX), faq.answer)
+      .input('enabled', sql.Bit, true)
+      .input('tags', sql.NVarChar(200), faq.tags)
+      .query(
+        'INSERT INTO FAQs (tenant_id, question, answer, enabled, tags) VALUES (@tenantId, @question, @answer, @enabled, @tags)'
+      );
+  }
+};
+
+const ensureReservationForm = async (tenantId: number): Promise<number> => {
+  const pool = await getPool();
+  const existing = await pool
+    .request()
+    .input('tenantId', sql.Int, tenantId)
+    .input('name', sql.NVarChar(100), '訂位')
+    .query('SELECT id FROM Forms WHERE tenant_id = @tenantId AND name = @name');
+
+  if (existing.recordset.length > 0) {
+    return existing.recordset[0].id as number;
+  }
+
+  const schema = {
+    title: '訂位',
+    fields: [
+      { name: 'partySize', label: '人數', type: 'number', required: true },
+      { name: 'date', label: '日期', type: 'date', required: true },
+      {
+        name: 'session',
+        label: '時段',
+        type: 'select',
+        required: true,
+        options: [
+          { label: '午', value: 'lunch' },
+          { label: '晚', value: 'dinner' },
+        ],
+      },
+      { name: 'name', label: '姓名', type: 'text', required: true },
+      { name: 'phone', label: '電話', type: 'text', required: true },
+    ],
+  };
+
+  const inserted = await pool
+    .request()
+    .input('tenantId', sql.Int, tenantId)
+    .input('name', sql.NVarChar(100), '訂位')
+    .input('schemaJson', sql.NVarChar(sql.MAX), JSON.stringify(schema))
+    .input('triggerKeywords', sql.NVarChar(300), '訂位,定位,預約')
+    .input('enabled', sql.Bit, true)
+    .query(
+      'INSERT INTO Forms (tenant_id, name, schema_json, trigger_keywords, enabled) OUTPUT INSERTED.id VALUES (@tenantId, @name, @schemaJson, @triggerKeywords, @enabled)'
+    );
+
+  return inserted.recordset[0].id as number;
+};
+
+const main = async () => {
+  try {
+    const tenantId = await ensureTenant();
+    await ensureOwner(tenantId);
+    await ensureTelegramChannel(tenantId);
+    await ensureFaqs(tenantId);
+    await ensureReservationForm(tenantId);
+  } catch (error) {
+    console.error('Seed failed', error);
+    process.exitCode = 1;
+  } finally {
+    await closePool();
+  }
+};
+
+void main();

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add an initial SQL Server migration covering tenants, channels, conversations, FAQs, forms, and jobs
- implement MSSQL connection pooling plus migration and seed runners in the API package
- document how to execute the migration and seed scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db55e111208329984daeb8c5002f50